### PR TITLE
feat: add print-ready views for outsourcing and shipping

### DIFF
--- a/app/sheet/[id]/page.tsx
+++ b/app/sheet/[id]/page.tsx
@@ -6,7 +6,7 @@ import {
 } from 'react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
-import { Plus, List, Star, Folder, Cloud, Lock, ChevronDown } from 'lucide-react';
+import { Plus, List, Star, Folder, Cloud, Lock, ChevronDown, Printer } from 'lucide-react';
 import SpreadsheetGrid from '@/components/spreadsheet/Grid';
 import SheetsIcon from '@/components/icons/SheetsIcon';
 import { MasterDataRow, CellAddress } from '@/components/spreadsheet/types';
@@ -510,6 +510,19 @@ export default function SheetEditorPage() {
           if (editingCell) cancelEdit();
         }}
       />
+
+      {(activeSheet === '外协' || activeSheet === '出货') && (
+        <button
+          onClick={() => {
+            const mode = activeSheet === '外协' ? 'outsourcing' : 'shipping';
+            window.open(`/sheet/${sheetId}/print/${mode}`, '_blank');
+          }}
+          className="fixed bottom-4 right-4 rounded-full bg-white/90 p-3 shadow-lg border hover:bg-white"
+          aria-label="Print"
+        >
+          <Printer className="h-5 w-5" />
+        </button>
+      )}
     </div>
   );
 }

--- a/app/sheet/[id]/print/[mode]/PrintClient.tsx
+++ b/app/sheet/[id]/print/[mode]/PrintClient.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useEffect } from 'react';
+import type { SheetRow } from '@/lib/db';
+
+export default function PrintClient({ sheet, mode }: { sheet: SheetRow; mode: 'outsourcing' | 'shipping'; }) {
+  useEffect(() => {
+    window.print();
+  }, []);
+
+  const rows = sheet.data.masterData.filter(r => {
+    const hasContent = r.productName || r.productNumber || r.material || r.quantity || r.remarks;
+    return (mode === 'outsourcing' ? r.isOutsourced : true) && hasContent;
+  });
+  const data = mode === 'outsourcing' ? sheet.data.outsourcingData : sheet.data.shippingData;
+  const title = mode === 'outsourcing' ? '外协单' : '送货单';
+
+  return (
+    <div className="p-6 text-sm">
+      <h1 className="text-2xl font-bold text-center mb-2">{data.ourCompany || '杭州越侬模型科技有限公司'}</h1>
+      <h2 className="text-lg font-semibold text-center mb-4">{title}</h2>
+
+      <div className="mb-4 space-y-1">
+        {mode === 'outsourcing' ? (
+          <>
+            <div>对方名称：{data.counterpartName}</div>
+            <div>对方联系人：{data.counterpartContact}</div>
+            <div>外协单号：{data.outsourceOrderNumber}</div>
+            <div>寄出时间：{data.dispatchDate}</div>
+            <div>寄回时间：{data.returnDate}</div>
+            <div>订单金额：{data.orderAmount}</div>
+            <div>我方：{data.ourCompany}</div>
+            <div>我方收件地址：{data.ourAddress}</div>
+            <div>我方联系人：{data.ourContact}</div>
+            <div>备注：{data.remarks}</div>
+          </>
+        ) : (
+          <>
+            <div>客户名称：{data.customerName}</div>
+            <div>客户联系人：{data.customerContact}</div>
+            <div>联系方式：{data.contactPhone}</div>
+            <div>生产单号：{data.productionOrderNumber}</div>
+            <div>合同编号：{data.contractNumber}</div>
+            <div>送货日期：{data.deliveryDate}</div>
+            <div>货品总数：{data.totalProductCount}</div>
+            <div>我方：{data.ourCompany}</div>
+            <div>我方联系人：{data.ourContact}</div>
+            <div>备注：{data.remarks}</div>
+          </>
+        )}
+      </div>
+
+      <table className="w-full border border-black border-collapse">
+        <thead>
+          <tr>
+            <th className="border p-1">序号</th>
+            <th className="border p-1">产品编号</th>
+            <th className="border p-1">产品名称</th>
+            <th className="border p-1">材料</th>
+            <th className="border p-1">{mode === 'outsourcing' ? '数量' : '交货数量'}</th>
+            <th className="border p-1">备注</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r, i) => (
+            <tr key={i}>
+              <td className="border p-1 text-center">{i + 1}</td>
+              <td className="border p-1">{r.productNumber}</td>
+              <td className="border p-1">{r.productName}</td>
+              <td className="border p-1">{r.material}</td>
+              <td className="border p-1">{r.quantity}</td>
+              <td className="border p-1">{r.remarks}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/app/sheet/[id]/print/[mode]/page.tsx
+++ b/app/sheet/[id]/print/[mode]/page.tsx
@@ -1,0 +1,11 @@
+import { getSheet } from '@/lib/db';
+import PrintClient from './PrintClient';
+
+export default async function PrintPage({ params }: { params: { id: string; mode: string } }) {
+  const sheet = getSheet(params.id);
+  if (!sheet) {
+    return <div className="p-4">Not found</div>;
+  }
+  const mode = params.mode === 'outsourcing' ? 'outsourcing' : 'shipping';
+  return <PrintClient sheet={sheet} mode={mode} />;
+}


### PR DESCRIPTION
## Summary
- add dedicated print routes for outsourcing and shipping orders
- expose a floating print button on outsourcing and shipping sheets
- auto-generate print-friendly tables with company header

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and other existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b191180cc0832dac9fb8bb06a0c0cb